### PR TITLE
Python 3.6, Use Openlane Opendbpy

### DIFF
--- a/dffram-env.Dockerfile
+++ b/dffram-env.Dockerfile
@@ -1,0 +1,3 @@
+FROM efabless/openlane:v0.15
+
+RUN python3 -m pip install click pyyaml

--- a/dffram.py
+++ b/dffram.py
@@ -138,7 +138,7 @@ def run_docker(image, args):
 
 def openlane(*args_tuple):
     args = list(args_tuple)
-    run_docker("efabless/openlane:v0.15", args)
+    run_docker("dffram-env", args)
 
 def sta(build_folder, design, netlist, spef_file=None):
     print("--- Static Timing Analysis ---")
@@ -255,8 +255,8 @@ def placeram(in_file, out_file, size, building_blocks, dimensions=os.devnull, re
     print("--- placeRAM Script ---")
     unaltered = out_file + ".ref"
 
-    run_docker("cloudv/dffram-env", [
-        "-python", "-m", "placeram",
+    openlane(
+        "python3", "-m", "placeram",
         "--output", unaltered,
         "--lef", "%s/sky130_fd_sc_hd.lef" % pdk_lef_dir,
         "--tech-lef", "%s/sky130_fd_sc_hd.tlef" % pdk_tlef_dir,
@@ -265,7 +265,7 @@ def placeram(in_file, out_file, size, building_blocks, dimensions=os.devnull, re
         "--represent", represent,
         "--building-blocks", building_blocks,
         in_file
-    ])
+    )
 
     unaltered_str = open(unaltered).read()
 
@@ -585,6 +585,10 @@ def antenna_check(build_folder, def_file, out_file):
 @click.option("-v", "--variant", default=None, help="Use design variants (such as 1RW1R)")
 def flow(frm, to, only, pdk_root, skip, size, building_blocks, variant):
     global bb_used
+
+    subprocess.run([
+        "docker", "build", "-t", "dffram-env", "-f", "dffram-env.Dockerfile", "."      
+    ], check=True)
 
     if variant == "DEFAULT":
         variant = None

--- a/dffram.py
+++ b/dffram.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf8 -*-
 # Copyright ©2020-2021 The American University in Cairo and the Cloud V Project.
 #
 # This file is part of the DFFRAM Memory Compiler.
@@ -130,7 +131,9 @@ def run_docker(image, args):
         "-v", "%s:/mnt/dffram" % rp("."),
         "-w", "/mnt/dffram",
         "-e", "PDK_ROOT=%s" % (pdk_root),
-        "-e", "PDKPATH=%s/sky130A" % (pdk_root)
+        "-e", "PDKPATH=%s/sky130A" % (pdk_root),
+        "-e", "LC_ALL=en_US.UTF-8",
+        "-e", "LANG=en_US.UTF-8"
     ] + [image] + args, check=True)
 
 def openlane(*args_tuple):
@@ -253,7 +256,7 @@ def placeram(in_file, out_file, size, building_blocks, dimensions=os.devnull, re
     unaltered = out_file + ".ref"
 
     run_docker("cloudv/dffram-env", [
-        "python3", "-m", "placeram",
+        "-python", "-m", "placeram",
         "--output", unaltered,
         "--lef", "%s/sky130_fd_sc_hd.lef" % pdk_lef_dir,
         "--tech-lef", "%s/sky130_fd_sc_hd.tlef" % pdk_tlef_dir,

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -11,9 +11,8 @@ DFFRAM is based around two Python modules: `dffram` and `placeram`.
 * The Skywater 130nm PDK
   * See [Getting Sky130](./md/Getting%20Sky130.md)
 * Docker Container
-* Python 3.8+ with PIP
-  * PlaceRAM makes heavy use of `:=` and is unrepentant.
-* PIP packages `click` and `pyyaml`: `python3 -m pip install click pyyaml`
+* Python 3.6+ with PIP
+  * PIP packages `click` and `pyyaml`: `python3 -m pip install click pyyaml`
 
 ## Recommended
 * Klayout (to view the final result)

--- a/openlane/rtl/RTL_openlane_flow.py
+++ b/openlane/rtl/RTL_openlane_flow.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf8 -*-
 # Copyright ©2020-2021 The American University in Cairo and the Cloud V Project.
 #
 # This file is part of the DFFRAM Memory Compiler.

--- a/placeram/__init__.py
+++ b/placeram/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf8 -*-
 # Copyright ©2020-2021 The American University in Cairo and the Cloud V Project.
 #
 # This file is part of the DFFRAM Memory Compiler.

--- a/placeram/__main__.py
+++ b/placeram/__main__.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf8 -*-
 # Copyright ©2020-2021 The American University in Cairo and the Cloud V Project.
 #
 # This file is part of the DFFRAM Memory Compiler.

--- a/placeram/cli.py
+++ b/placeram/cli.py
@@ -1,3 +1,4 @@
+# -*- coding: utf8 -*-
 # Copyright ©2020-2021 The American University in Cairo and the Cloud V Project.
 #
 # This file is part of the DFFRAM Memory Compiler.
@@ -16,17 +17,12 @@
 # limitations under the License.
 
 try:
-    import opendbpy as odb
-except ImportError:
-    print(
-    """
-    You need to install opendb (Ahmed Ghazy's fork):
-    https://github.com/ax3ghazy/opendb
-    Build normally then go to ./build/src/swig/python and run:
-
-    python3 setup.py install
-
-    (On macOS rename the .dylib to .so first)
+    import opendb as odb
+except:
+    print("""
+    placeram needs to be inside OpenROAD:
+    
+    openroad -python -m placeram [args]
     """)
     exit(78)
 
@@ -34,6 +30,12 @@ try:
     import click
 except ImportError:
     print("You need to install click: python3 -m pip install click")
+    exit(78)
+
+try:
+    import yaml
+except ImportError:
+    print("You need to install pyyaml: python3 -m pip install pyyank")
     exit(78)
 
 from .util import eprint
@@ -44,7 +46,6 @@ from .reg_data import DFFRF
 
 import os
 import re
-import yaml
 import traceback
 
 class Placer:

--- a/placeram/cli.py
+++ b/placeram/cli.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 
 try:
-    import opendb as odb
+    import opendbpy as odb
 except:
     print("""
     placeram needs to be inside OpenROAD:

--- a/placeram/data.py
+++ b/placeram/data.py
@@ -20,7 +20,7 @@ from .util import d2a, sarv
 from .row import Row
 from .placeable import Placeable, DataError, RegExp
 
-from opendb import dbInst as Instance
+from opendbpy import dbInst as Instance
 
 import re
 import sys

--- a/placeram/placeable.py
+++ b/placeram/placeable.py
@@ -1,11 +1,11 @@
 import os
 import sys
 import yaml
-from opendbpy import dbInst as Instance
+from opendb import dbInst as Instance
 from typing import List, Dict, Union, TextIO, Optional
+from types import SimpleNamespace
 
 from .row import Row
-from .util import Bunch
 
 RegExp = str
 
@@ -31,12 +31,12 @@ class Placeable(object):
     def word_count(self):
         raise Exception("Method unimplemented.")
 
-    def regexes(self) -> Bunch:
+    def regexes(self) -> SimpleNamespace:
         """
         Returns a dictionary of regexes for this class accessible with the dot
         notation.
         """
-        return Bunch(RegexDictionary[self.__class__.__name__])
+        return SimpleNamespace(**RegexDictionary[self.__class__.__name__])
 
     @staticmethod
     def represent_instance(

--- a/placeram/placeable.py
+++ b/placeram/placeable.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import yaml
-from opendb import dbInst as Instance
+from opendbpy import dbInst as Instance
 from typing import List, Dict, Union, TextIO, Optional
 from types import SimpleNamespace
 

--- a/placeram/reg_data.py
+++ b/placeram/reg_data.py
@@ -1,3 +1,4 @@
+# -*- coding: utf8 -*-
 # Copyright ©2020-2021 The American University in Cairo and the Cloud V Project.
 #
 # This file is part of the DFFRAM Memory Compiler.
@@ -16,13 +17,14 @@
 # limitations under the License.
 
 from .row import Row
-from .util import d2a
+from .util import d2a, sarv
 from .placeable import Placeable, DataError
 
-from opendbpy import dbInst
+from opendb import dbInst
 Instance = dbInst
 
 import re
+from types import SimpleNamespace as NS
 
 P = Placeable
 
@@ -45,34 +47,36 @@ class Word(Placeable):
         raw_invs1 = {}
         raw_invs2 = {}
 
+        m = NS()
         for instance in instances:
+
             n = instance.getName()
 
-            if clkgate_match := re.search(clkgate, n):
-                i = int(clkgate_match[1])
+            if sarv(m, "clkgate_match", re.search(clkgate, n)):
+                i = int(m.clkgate_match[1])
                 raw_clkgates[i] = instance
 
-            elif inv1_match := re.search(inv1, n):
-                i = int(inv1_match[1])
+            elif sarv(m, "inv1_match", re.search(inv1, n)):
+                i = int(m.inv1_match[1])
                 raw_invs1[i] = instance
 
-            elif inv2_match := re.search(inv2, n):
-                i = int(inv2_match[1])
+            elif sarv(m, "inv2_match", re.search(inv2, n)):
+                i = int(m.inv2_match[1])
                 raw_invs2[i] = instance
 
-            elif bit_ff_match := re.search(bit_ff, n):
-                i = int(bit_ff_match[1])
+            elif sarv(m, "bit_ff_match", re.search(bit_ff, n)):
+                i = int(m.bit_ff_match[1])
                 raw_ffs[i] = instance
 
-            elif bit_obuf1_match := re.search(bit_obuf1, n):
-                i = int(bit_obuf1_match[1])
+            elif sarv(m, "bit_obuf1_match", re.search(bit_obuf1, n)):
+                i = int(m.bit_obuf1_match[1])
                 raw_obufs1[i] = instance
 
-            elif bit_obuf2_match := re.search(bit_obuf2, n):
-                i = int(bit_obuf2_match[1])
+            elif sarv(m, "bit_obuf2_match", re.search(bit_obuf2, n)):
+                i = int(m.bit_obuf2_match[1])
                 raw_obufs2[i] = instance
 
-            elif clkgateand_match := re.search(clkgateand, n):
+            elif sarv(m, "clkgateand_match", re.search(clkgateand, n)):
                 self.clkgateand = instance
 
             else:
@@ -132,37 +136,39 @@ class DFFRF(Placeable): # 32 words
         rfw0_obuf1 = r"\bRFW0\.BIT\\\[(\d+)\\\]\.OBUF1\b"
         rfw0_obuf2 = r"\bRFW0\.BIT\\\[(\d+)\\\]\.OBUF2\b"
 
+        m = NS()
         for instance in instances:
+
             n = instance.getName()
 
-            if word_match := re.search(word, n):
-                i = int(word_match[1])
+            if sarv(m, "word_match", re.search(word, n)):
+                i = int(m.word_match[1])
                 raw_words[i] = raw_words.get(i) or []
                 raw_words[i].append(instance)
 
-            elif decoder5x32_match := re.search(decoder5x32, n):
-                i = int(decoder5x32_match[1])
+            elif sarv(m, "decoder5x32_match", re.search(decoder5x32, n)):
+                i = int(m.decoder5x32_match[1])
                 raw_decoders5x32[i] = raw_decoders5x32.get(i) or []
                 raw_decoders5x32[i].append(instance)
 
-            elif rfw0_obuf_match1 := re.search(rfw0_obuf1, n):
-                bit = int(rfw0_obuf_match1[1])
+            elif sarv(m, "rfw0_obuf_match1", re.search(rfw0_obuf1, n)):
+                bit = int(m.rfw0_obuf_match1[1])
                 raw_rfw0_obufs1[bit] = instance
 
-            elif rfw0_obuf_match2 := re.search(rfw0_obuf2, n):
-                bit = int(rfw0_obuf_match2[1])
+            elif sarv(m, "rfw0_obuf_match2", re.search(rfw0_obuf2, n)):
+                bit = int(m.rfw0_obuf_match2[1])
                 raw_rfw0_obufs2[bit] = instance
 
-            elif rfw0_tie_match := re.search(rfw0_tie, n):
-                i = int(rfw0_tie_match[1])
+            elif sarv(m, "rfw0_tie_match", re.search(rfw0_tie, n)):
+                i = int(m.rfw0_tie_match[1])
                 raw_rfw0_ties[i] = instance
 
-            elif rfw0_inv1_match := re.search(rfw0_inv1, n):
-                i = int(rfw0_inv1_match[1])
+            elif sarv(m, "rfw0_inv1_match", re.search(rfw0_inv1, n)):
+                i = int(m.rfw0_inv1_match[1])
                 raw_rfw0_invs1[i] = instance
 
-            elif rfw0_inv2_match := re.search(rfw0_inv2, n):
-                i = int(rfw0_inv2_match[1])
+            elif sarv(m, "rfw0_inv2_match", re.search(rfw0_inv2, n)):
+                i = int(m.rfw0_inv2_match[1])
                 raw_rfw0_invs2[i] = instance
 
             else:
@@ -281,15 +287,17 @@ class Decoder5x32(Placeable):
         raw_decoders3x8 = {} # multiple decoders so multiple entries ordered by 1st match
         self.decoder2x4 = [] # one decoder so array
 
+        m = NS()
         for instance in instances:
+
             n = instance.getName()
 
-            if decoder3x8_match := re.search(decoder3x8, n):
-                i = int(decoder3x8_match[2])
+            if sarv(m, "decoder3x8_match", re.search(decoder3x8, n)):
+                i = int(m.decoder3x8_match[2])
                 raw_decoders3x8[i] = raw_decoders3x8.get(i) or []
                 raw_decoders3x8[i].append(instance)
 
-            elif decoder2x4_match := re.search(decoder2x4, n):
+            elif sarv(m, "decoder2x4_match", re.search(decoder2x4, n)):
                 # TODO(ahmednofal): check if these instances
                 # are not ordered so it might not be
                 # the most optimal placement
@@ -325,11 +333,13 @@ class Decoder3x8(Placeable):
 
         raw_andgates = {} # multiple decoders so multiple entries ordered by 1st match
 
+        m = NS()
         for instance in instances:
+
             n = instance.getName()
 
-            if andgate_match := re.search(andgate, n):
-                i = int(andgate_match[1])
+            if sarv(m, "andgate_match", re.search(andgate, n)):
+                i = int(m.andgate_match[1])
                 raw_andgates[i] = raw_andgates.get(i) or []
                 raw_andgates[i] = instance
             else:
@@ -358,11 +368,13 @@ class Decoder2x4(Placeable):
 
         raw_andgates = {} # multiple decoders so multiple entries ordered by 1st match
 
+        m = NS()
         for instance in instances:
+
             n = instance.getName()
 
-            if andgate_match := re.search(andgate, n):
-                i = int(andgate_match[1])
+            if sarv(m, "andgate_match", re.search(andgate, n)):
+                i = int(m.andgate_match[1])
                 raw_andgates[i] = raw_andgates.get(i) or []
                 raw_andgates[i] = instance
             else:

--- a/placeram/reg_data.py
+++ b/placeram/reg_data.py
@@ -20,7 +20,7 @@ from .row import Row
 from .util import d2a, sarv
 from .placeable import Placeable, DataError
 
-from opendb import dbInst
+from opendbpy import dbInst
 Instance = dbInst
 
 import re

--- a/placeram/row.py
+++ b/placeram/row.py
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
  
-from opendb import dbRow, dbInst, dbSite
+from opendbpy import dbRow, dbInst, dbSite
 from typing import List, Callable
 
 class Row(object):

--- a/placeram/row.py
+++ b/placeram/row.py
@@ -1,3 +1,4 @@
+# -*- coding: utf8 -*-
 # Copyright ©2020-2021 The American University in Cairo and the Cloud V Project.
 #
 # This file is part of the DFFRAM Memory Compiler.
@@ -15,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
  
-from opendbpy import dbRow, dbInst, dbSite
+from opendb import dbRow, dbInst, dbSite
 from typing import List, Callable
 
 class Row(object):

--- a/placeram/util.py
+++ b/placeram/util.py
@@ -1,3 +1,4 @@
+# -*- coding: utf8 -*-
 # Copyright ©2020-2021 The American University in Cairo and the Cloud V Project.
 #
 # This file is part of the DFFRAM Memory Compiler.
@@ -16,7 +17,8 @@
 # limitations under the License.
 
 import sys
-from typing import Dict, List, T
+from types import SimpleNamespace
+from typing import Any, Dict, List, T
 
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
@@ -31,12 +33,11 @@ def d2a(d: Dict[int, T]) -> List[T]:
     as_list.sort(key=lambda x: x[0])
     return list(map(lambda x: x[1], as_list))
 
-
-class Bunch:
+def sarv(obj: SimpleNamespace, name: str, expr: T) -> T:
     """
-    An immutable, dot-notation-accessible dictionary.
+    Set Attribute And Return Value
 
-    Buildable from an actual dictionary.
+    A workaround for := not being available below Python 3.8.
     """
-    def __init__(self, hashmap: Dict):
-        setattr(self, '__dict__', hashmap)
+    setattr(obj, name, expr)
+    return expr

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 click
-yaml
+pyyaml

--- a/verification/tb_template.py
+++ b/verification/tb_template.py
@@ -1,3 +1,4 @@
+# -*- coding: utf8 -*-
 # Copyright ©2020-2021 The American University in Cairo and the Cloud V Project.
 #
 # This file is part of the DFFRAM Memory Compiler.


### PR DESCRIPTION
This downgrades to Python 3.6 (which looks to me like it's the EDA de-facto standard) and uses Openlane's built-in Opendbpy instead of maintaining our own. 