### PR TITLE
Write abstract LEF files

### DIFF
--- a/dffram.py
+++ b/dffram.py
@@ -481,7 +481,7 @@ def write_ram_lef(design, in_file, out_file):
         lef read {build_folder}/merged.lef
         def read {in_file}
         load {design} -dereference
-        lef write {out_file}
+        lef write {out_file} -hide
         """)
 
     openlane("magic",


### PR DESCRIPTION
When building a large RAM (eg 4kB), I end up with a huge LEF file that
is over 400MB in size. After switching to abstract LEF files (write lef
-hide), it drops to 44kB.