### PR TITLE
Expand the register file functionality to support variable bit width

### DIFF
--- a/dffram.py
+++ b/dffram.py
@@ -130,12 +130,22 @@ def cl():
 
 # Not true synthesis, just elaboration.
 def synthesis(
-    design, building_blocks, synth_info, widths_supported, word_width_bytes, out_file
+    design,
+    building_blocks,
+    synth_info,
+    widths_supported,
+    word_width_bytes,
+    out_file,
+    word_width,
+    blocks,
 ):
     print("--- Synthesis ---")
     chparam = ""
     if len(widths_supported) > 1:
-        chparam = "catch { chparam -set WSIZE %i %s }" % (word_width_bytes, design)
+        if blocks == "rf":
+            chparam = "catch { chparam -set WSIZE %i %s }" % (word_width, design)
+        else:
+            chparam = "catch { chparam -set WSIZE %i %s }" % (word_width_bytes, design)
     with open(f"{build_folder}/synth.tcl", "w") as f:
         print(design)
         f.write(
@@ -613,7 +623,14 @@ def flow(
         (
             "synthesis",
             lambda: synthesis(
-                design, bb_used, synth_info, config["widths"], word_width_bytes, netlist
+                design,
+                bb_used,
+                synth_info,
+                config["widths"],
+                word_width_bytes,
+                netlist,
+                word_width,
+                blocks,
             ),
         ),
         ("placement", lambda: placement(width, height)),

--- a/placeram/reg_data.py
+++ b/placeram/reg_data.py
@@ -51,16 +51,16 @@ class Bit(Placeable):
 class RFWord(Placeable):
     def __init__(self, instances):
 
-        raw_bits: Dict[int, List[Instance]] = {}
+        self.raw_bits: Dict[int, List[Instance]] = {}
 
         def process_bit(instance, bit):
-            raw_bits[bit] = raw_bits.get(bit) or []
-            raw_bits[bit].append(instance)
+            self.raw_bits[bit] = self.raw_bits.get(bit) or []
+            self.raw_bits[bit].append(instance)
 
         self.sieve(
             instances,
             [
-                S(variable="bit", groups=["bit"], custom_behavior=process_bit),
+                S(variable="ffs", groups=["bit"], custom_behavior=process_bit),
                 S(variable="clkgateand"),
                 S(variable="clkgates", groups=["ports"]),
                 S(variable="obufs", groups=["ports", "bit"], group_rx_order=[2, 1]),
@@ -69,7 +69,6 @@ class RFWord(Placeable):
         )
 
         self.dicts_to_lists()
-        self.bits = d2a({k: Bit(v) for k, v in raw_bits.items()})
 
     def place(self, row_list, start_row=0):
         raise Exception(
@@ -77,10 +76,7 @@ class RFWord(Placeable):
         )
 
     def word_width(self):
-
-        # we do the filteration proccess on the netlist to get bits for a word
-        # so we wanna iterate on the list to count the number of ffs/bits and return the word count
-        return len(self.bits)
+        return len(self.raw_bits)
 
     def word_count(self):
         return 1
@@ -133,7 +129,7 @@ class DFFRF(Placeable):  # 32 words
         # 32 _ ====================================  ____  32
         # { D2 ====================================  D0 D1  }
         word_rows = 32 * 2 - 2 + 1  # word 0 only needs one row
-        word_width = self.words[0].word_width
+        word_width = self.words[0].word_width()
 
         # D2 placement
         self.decoders5x32[2].place(rows, start_row, (32 - 4) // 2, flip=True)

--- a/platforms/sky130A/sky130_fd_sc_hd/_building_blocks/rf/config.yml
+++ b/platforms/sky130A/sky130_fd_sc_hd/_building_blocks/rf/config.yml
@@ -1,5 +1,5 @@
 counts: [32]
-widths: [32]
+widths: [8,16,32,64,128,256]
 design_name_template: "DFFRF{variant}"
 register_file: true
 tap_distance: 15

--- a/platforms/sky130A/sky130_fd_sc_hd/_building_blocks/rf/model.v
+++ b/platforms/sky130A/sky130_fd_sc_hd/_building_blocks/rf/model.v
@@ -78,31 +78,31 @@ module DEC5x32 (
 	DEC2x4 D ( .A(A[4:3]), .SEL(EN), .EN(hi) );
 endmodule
 
-module RFWORD #(parameter RWIDTH=32) 
+module RFWORD #(parameter WSIZE=32) 
 (
     input   wire                CLK,
     input   wire                WE,
     input   wire                SEL1, 
     input   wire                SEL2, 
     input   wire                SELW,
-    output  wire [RWIDTH-1:0]   D1, D2,
-    input   wire [RWIDTH-1:0]   DW
+    output  wire [WSIZE-1:0]   D1, D2,
+    input   wire [WSIZE-1:0]   DW
 );
 
-    wire [RWIDTH-1:0]   q_wire;
+    wire [WSIZE-1:0]   q_wire;
     wire                we_wire;
-    wire [(RWIDTH/8)-1:0]          SEL1_B, SEL2_B;
-    wire [(RWIDTH/8)-1:0]          GCLK;
+    wire [(WSIZE/8)-1:0]          SEL1_B, SEL2_B;
+    wire [(WSIZE/8)-1:0]          GCLK;
 
-    sky130_fd_sc_hd__inv_4 INV1[(RWIDTH/8)-1:0] (.Y(SEL1_B), .A(SEL1));
-	sky130_fd_sc_hd__inv_4 INV2[(RWIDTH/8)-1:0] (.Y(SEL2_B), .A(SEL2));
+    sky130_fd_sc_hd__inv_4 INV1[(WSIZE/8)-1:0] (.Y(SEL1_B), .A(SEL1));
+	sky130_fd_sc_hd__inv_4 INV2[(WSIZE/8)-1:0] (.Y(SEL2_B), .A(SEL2));
 
     sky130_fd_sc_hd__and2_1 CGAND ( .A(SELW), .B(WE), .X(we_wire) );
-    sky130_fd_sc_hd__dlclkp_1 CG[(RWIDTH/8)-1:0] ( .CLK(CLK), .GCLK(GCLK), .GATE(we_wire) );
+    sky130_fd_sc_hd__dlclkp_1 CG[(WSIZE/8)-1:0] ( .CLK(CLK), .GCLK(GCLK), .GATE(we_wire) );
 
     generate 
         genvar i;
-        for(i=0; i<RWIDTH; i=i+1) begin : BIT
+        for(i=0; i<WSIZE; i=i+1) begin : BIT
             sky130_fd_sc_hd__dfxtp_1 FF ( .D(DW[i]), .Q(q_wire[i]), .CLK(GCLK[i/8]) );
             sky130_fd_sc_hd__ebufn_2 OBUF1 ( .A(q_wire[i]), .Z(D1[i]), .TE_B(SEL1_B[i/8]) );
 			sky130_fd_sc_hd__ebufn_2 OBUF2 ( .A(q_wire[i]), .Z(D2[i]), .TE_B(SEL2_B[i/8]) );
@@ -111,29 +111,29 @@ module RFWORD #(parameter RWIDTH=32)
     endgenerate 
 endmodule
 
-module RFWORD0 #(parameter RWIDTH=32)
+module RFWORD0 #(parameter WSIZE=32)
 (
     input   wire                CLK,
     input   wire                SEL1, 
     input   wire                SEL2, 
     input   wire                SELW,
-    output  wire [RWIDTH-1:0]   D1, D2
+    output  wire [WSIZE-1:0]   D1, D2
 );
 
-    wire [RWIDTH-1:0]           q_wire;
+    wire [WSIZE-1:0]           q_wire;
     wire                        we_wire;
-    wire [(RWIDTH/8)-1:0]                  SEL1_B, SEL2_B;
-    wire [(RWIDTH/8)-1:0]                  GCLK;
+    wire [(WSIZE/8)-1:0]                  SEL1_B, SEL2_B;
+    wire [(WSIZE/8)-1:0]                  GCLK;
 	wire [7:0]	                lo;
 
-    sky130_fd_sc_hd__inv_4 INV1[(RWIDTH/8)-1:0] (.Y(SEL1_B), .A(SEL1));
-	sky130_fd_sc_hd__inv_4 INV2[(RWIDTH/8)-1:0] (.Y(SEL2_B), .A(SEL2));
+    sky130_fd_sc_hd__inv_4 INV1[(WSIZE/8)-1:0] (.Y(SEL1_B), .A(SEL1));
+	sky130_fd_sc_hd__inv_4 INV2[(WSIZE/8)-1:0] (.Y(SEL2_B), .A(SEL2));
 
 	sky130_fd_sc_hd__conb_1 TIE [7:0] (.LO(lo), .HI());
 
     generate 
         genvar i;
-        for(i=0; i<RWIDTH; i=i+1) begin : BIT
+        for(i=0; i<WSIZE; i=i+1) begin : BIT
             sky130_fd_sc_hd__ebufn_2 OBUF1 ( .A(lo[i/8]), .Z(D1[i]), .TE_B(SEL1_B[i/8]) );
 			sky130_fd_sc_hd__ebufn_2 OBUF2 ( .A(lo[4+i/8]), .Z(D2[i]), .TE_B(SEL2_B[i/8]) );
         end
@@ -141,13 +141,13 @@ module RFWORD0 #(parameter RWIDTH=32)
 endmodule
 
 
-module DFFRF_2R1W #(parameter   RWIDTH=32,
+module DFFRF_2R1W #(parameter   WSIZE=32,
                                 RCOUNT=32,
                                 R0_ZERO=1 )
 (
 	input   wire    [4:0]                   RA, RB, RW,
-	input   wire    [RWIDTH-1:0]         	DW,
-	output  wire    [RWIDTH-1:0]        	DA, DB,
+	input   wire    [WSIZE-1:0]         	DW,
+	output  wire    [WSIZE-1:0]        	DA, DB,
 	input   wire                            CLK,
 	input   wire                            WE
 );
@@ -160,12 +160,12 @@ module DFFRF_2R1W #(parameter   RWIDTH=32,
 	generate
 		genvar e;
         if(R0_ZERO == 1)
-            RFWORD0 #(.RWIDTH(RWIDTH)) RFW0 ( .CLK(CLK), .SEL1(sel1[0]), .SEL2(sel2[0]), .SELW(selw[0]), .D1(DA), .D2(DB));	
+            RFWORD0 #(.WSIZE(WSIZE)) RFW0 ( .CLK(CLK), .SEL1(sel1[0]), .SEL2(sel2[0]), .SELW(selw[0]), .D1(DA), .D2(DB));	
         else
-            RFWORD #(.RWIDTH(RWIDTH)) RFW0 ( .CLK(CLK), .WE(WE), .SEL1(sel1[0]), .SEL2(sel2[0]), .SELW(selw[0]), .D1(DA), .D2(DB), .DW(DW) );
+            RFWORD #(.WSIZE(WSIZE)) RFW0 ( .CLK(CLK), .WE(WE), .SEL1(sel1[0]), .SEL2(sel2[0]), .SELW(selw[0]), .D1(DA), .D2(DB), .DW(DW) );
 
         for(e=1; e<RCOUNT; e=e+1) begin : REGF 
-			RFWORD #(.RWIDTH(RWIDTH)) RFW ( .CLK(CLK), .WE(WE), .SEL1(sel1[e]), .SEL2(sel2[e]), .SELW(selw[e]), .D1(DA), .D2(DB), .DW(DW) );	
+			RFWORD #(.WSIZE(WSIZE)) RFW ( .CLK(CLK), .WE(WE), .SEL1(sel1[e]), .SEL2(sel2[e]), .SELW(selw[e]), .D1(DA), .D2(DB), .DW(DW) );	
         end
 	endgenerate
 endmodule

--- a/scripts/python/unplace.py
+++ b/scripts/python/unplace.py
@@ -66,7 +66,7 @@ def unplace(platform, output_file, input_file):
 
     replaced = 0
     for rx in rx_list:
-        frx = fr"({rx})\s*\+\s*PLACED\s*\(\s*\d+\s*\d+\s*\)\s*\w+"
+        frx = rf"({rx})\s*\+\s*PLACED\s*\(\s*\d+\s*\d+\s*\)\s*\w+"
         output_str, replacements = re.subn(frx, r"\1", output_str)
         replaced += replacements
 


### PR DESCRIPTION
Context: 
Expanding the register file functionality to support variable bit width. 

Changes: 
+ Modified config.yml for rf to support different widths (8, 16, 32, 64, 128, 256)
+ word_width is no longer hard coded in reg_data.py
+ the method synthesis in dffram.py now takes two more parameters to be able to pass the correct parameter for model.v
+ changed the parameter RWIDTH to WSIZE for the sake of consistency in model.v for rf. 
