### PR TITLE
Allow Openlane version to be overridden

### DIFF
--- a/dffram.py
+++ b/dffram.py
@@ -64,6 +64,7 @@ tool_metadata = yaml.safe_load(open(tool_metadata_file_path).read())
 openlane_version = [tool for tool in tool_metadata if tool["name"] == "openlane"][0][
     "commit"
 ]
+openlane_image = os.getenv("OPENLANE_IMAGE_NAME", default=f"efabless/openlane:{openlane_version}")
 
 running_docker_ids = set()
 
@@ -126,7 +127,7 @@ def openlane(*args_tuple):
 
         subprocess.check_call(args, env=env)
     else:
-        run_docker(f"efabless/openlane:{openlane_version}", args)
+        run_docker(openlane_image, args)
 
 
 def prep(local_pdk_root):


### PR DESCRIPTION
Use the OPENLANE_IMAGE_NAME environment variable to override the default
version of Openlane.