### PR TITLE
Fix interactive.tcl, OL Image Override

### DIFF
--- a/dffram.py
+++ b/dffram.py
@@ -69,7 +69,9 @@ tool_metadata = yaml.safe_load(open(tool_metadata_file_path).read())
 openlane_version = [tool for tool in tool_metadata if tool["name"] == "openlane"][0][
     "commit"
 ]
-openlane_image = os.getenv("OPENLANE_IMAGE_NAME", default=f"efabless/openlane:{openlane_version}")
+openlane_image = os.getenv(
+    "OPENLANE_IMAGE_NAME", default=f"efabless/openlane:{openlane_version}"
+)
 
 running_docker_ids = set()
 

--- a/dffram.py
+++ b/dffram.py
@@ -69,6 +69,7 @@ tool_metadata = yaml.safe_load(open(tool_metadata_file_path).read())
 openlane_version = [tool for tool in tool_metadata if tool["name"] == "openlane"][0][
     "commit"
 ]
+openlane_image = os.getenv("OPENLANE_IMAGE_NAME", default=f"efabless/openlane:{openlane_version}")
 
 running_docker_ids = set()
 
@@ -131,7 +132,7 @@ def openlane(*args_tuple):
 
         subprocess.check_call(args, env=env)
     else:
-        run_docker(f"efabless/openlane:{openlane_version}", args)
+        run_docker(openlane_image, args)
 
 
 def prep(local_pdk_root):

--- a/scripts/openlane/interactive.tcl
+++ b/scripts/openlane/interactive.tcl
@@ -19,6 +19,7 @@ set ::env(CURRENT_SDC) $::env(INITIAL_SDC)
 
 run_power_grid_generation
 run_routing
+run_parasitics_sta
 run_magic
 if {  [info exists ::env(ENABLE_KLAYOUT) ] } {
     if { ($::env(ENABLE_KLAYOUT) == 1)  } {
@@ -63,8 +64,8 @@ proc save_final_views {args} {
     lappend arg_list -verilog_path $::env(CURRENT_NETLIST)
 
     # Not guaranteed to have default values
-    if { [info exists ::env(SPEF_TYPICAL)] } {
-        lappend arg_list -spef_path $::env(SPEF_TYPICAL)
+    if { [info exists ::env(CURRENT_SPEF)] } {
+        lappend arg_list -spef_path $::env(CURRENT_SPEF)
     }
     if { [info exists ::env(CURRENT_SDF)] } {
         lappend arg_list -sdf_path $::env(CURRENT_SDF)


### PR DESCRIPTION
+ OPENLANE_IMAGE_NAME can now change the OpenLane Image being used
~ `interactive.tcl` updated to reflect changes in OpenLane