### PR TITLE
openlane ioplace path issue

### DIFF
--- a/dffram.py
+++ b/dffram.py
@@ -352,7 +352,7 @@ def place_pins(design, synth_info, in_file, out_file, pin_order_file):
         openlane(
             "openroad",
             "-python",
-            f"{openlane_scripts_path}/io_place.py",
+            f"{openlane_scripts_path}/odbpy/io_place.py",
             "--input-lef",
             f"{build_folder}/merged.lef",
             "--config",


### PR DESCRIPTION
Fixes the following error (using the latest tools):
```
--- Pin Placement ---
openroad: can't open file '/openlane/scripts/io_place.py': [Errno 2] No such file or directory
OpenROAD 0b8b7ae255f8fbbbefa57d443949b84e73eed757 
This program is licensed under the BSD-3 license. See the LICENSE file for details.

```