### PR TITLE
Fix datebase creation so it has a log with new OpenROAD

### DIFF
--- a/placeram/cli.py
+++ b/placeram/cli.py
@@ -23,6 +23,7 @@ import traceback
 try:
     import odb
     import utl
+    from openroad import Tech, Design
 except ImportError:
     print(
         """
@@ -63,9 +64,10 @@ class Placer:
         tap_distance,
     ):
         # Initialize Database
-        self.db = odb.dbDatabase.create()
-
-        odb.read_db(self.db, odb_in)
+        self.tech = Tech()
+        self.design = Design(self.tech)
+        self.design.readDb(odb_in)
+        self.db = self.tech.getDB()
 
         # Technology Setup
         self.libs = self.db.getLibs()


### PR DESCRIPTION
Quick hack to fix compatibility with OpenROAD from OpenLane 2.0.8.

Without this change, DFFRAM fails with:

[CRITICAL ODB-0001] No logger is installed in odb.
[15:32:37] ERROR    Subprocess had a non-zero exit.                                                                     step.py:1308
[15:32:37] ERROR    Last 3 line(s):                                                                                     step.py:1313
                    [WARNING ORD-0039] .openroad ignored with -python
                    [CRITICAL ODB-0001] No logger is installed in odb.