### PR TITLE
chore: replace openlane by librelane in tool_metadata.yml

### DIFF
--- a/tool_metadata.yml
+++ b/tool_metadata.yml
@@ -1,3 +1,3 @@
-- name: openlane
-  repo: https://github.com/The-OpenROAD-Project/OpenLane
-  commit: 2023.06.26
+- name: librelane
+  repo: https://github.com/librelane/librelane
+  commit: 2.4.2


### PR DESCRIPTION
This just replaces openlane by librelane in `tool_metadata.yml`, which was probably just overlooked in #200 :)

If this was however left in deliberately, just let me know.